### PR TITLE
ENH: Add University of Frankfurt

### DIFF
--- a/db/institutions.yml
+++ b/db/institutions.yml
@@ -495,3 +495,17 @@ addisababau:
   schools: {cns: {name: College of Natural Science}}
   state: ''
   zip: ''
+ufrankfurt:
+  aka: [University of Frankfurt, Frankfurt University, Goethe-Universität, Universität Frankfurt am Main]
+  city: Frankfurt
+  country: Germany
+  departments: {appphy: {name: Institute of Applied Physics}, biophy: {name: Institute of Biophysics},
+        phyedu: {name: Institute of Physics Education}, nucphy: {name: Institute of Nuclear Physics},
+        phy:{name: Institute of Physics} theophy: {name: Institute of Theoretical Physics}, inochem: 
+        {name: Institute of Inorganic and Analytical Chemistry}, orgchem: {name: Institute of Organic 
+        Chemistry and Chemical Biology}, phychem: {name: Institute of Physical and Theoretical Chemistry},
+        didchem: {name: Institute of Didactics of Chemistry}}
+  schools: {physics:{name: Department of Physics}, chemistry:{name: Department of Chemistry}}
+  name: Goethe University Frankfurt
+  state: ''                     
+  zip: 60323


### PR DESCRIPTION
This is for issue #52 .
No schools found for physics and chemistry depts. Instead, found `Institute of Theoretical Physics` under physics dept.