### PR TITLE
Add Uni Duisburg-Essen

### DIFF
--- a/db/institutions.yml
+++ b/db/institutions.yml
@@ -411,3 +411,13 @@ umontreal:
   state: Québec 
   street: 2900, boul. Édouard-Montpetit
   zip: H3T 1J4 
+uduisburgessen:
+  aka: [The University of Duisburg-Essen, Die Universität Duisburg-Essen, Uni DuE, UDE]
+  city: Essen
+  country: Germany
+  departments: {chemistry: {name: Institute of Inorganic Chemistry}, matsci: {name: Center for Nanointegration Duisburg-Essen (CENIDE)}}
+  name: University of Duisburg-Essen
+  state: North Rhine-Westphalia
+  street: Universitaetsstrasse 7
+  zip: 45117
+


### PR DESCRIPTION
Closes #73 

Quick question, for the departments should we ideally by adding departments where a collaborator exists, or what is this for? Like in this case for chemistry I put Institute of Inorganic Chemistry because this is where Epple and co. are, but there is also a separate Chemistry Department at the school. I'm guessing you don't want us to add every mat-sci related department at these universities manually.