### PR TITLE
WIP: change the CI back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,9 @@ script:
   - set -e
   - cd local
   - regolith validate
-
-deploy:
-  provider: script
-  on:
-    branch: master
-  script:
-    - git clone https://github.com/billingegroup/website.git;
-      cd website;
-      regolith build html;
-      cd ..;
-      doctr deploy --deploy-repo billingegroup/billingegroup.github.io --deploy-branch-name master --built-docs website/_build/html .;
+  - cd ..
+  - git clone https://github.com/billingegroup/website.git;
+    cd website;
+    regolith build html;
+    cd ..;
+    doctr deploy --deploy-repo billingegroup/billingegroup.github.io --deploy-branch-name master --built-docs website/_build/html .;


### PR DESCRIPTION
I checked that doctr doesn't need to be used in deploy. The doctr itself has the machenism to make sure the changes only pushed from master branch and there is ssh key for security. So I changed the CI back to Chris's version.

Because the new regolith needs pandas but there is no pandas in conda recipe so I add it in CI.