### PR TITLE
corrected syntax for jeaster entry in people.yml

### DIFF
--- a/db/people.yml
+++ b/db/people.yml
@@ -2126,16 +2126,25 @@ jchung:
   position: unknown
 jeaster:
   active: true
-  aka: []
+  aka:
+    - Jay Easter
+    - J. Y. Easter
+    - J. Easter
   avatar: https://github.com/easterjaylah.png
-  bio: ''
-  education: []
+  bio: Jay Easter is a Henson Entrepreneur Endowed Honors scholar at the
+    University of Maryland Eastern Shore, studying general engineering with a
+    mechanical engineering specialization. His general research interests pertain to
+    understanding the relationship between the atomic structure and the emergent
+    properties of organic materials for applications in energy, and the numerical 
+    modelling and fabrication of NEMS devices. Jay is passionate about entrepreneurship
+    and the integration of historically underrepresented groups in STEM.
+  education: BS General Engineering, mech. specialization (Expected Graduation: 5/2023)
   email: jyeaster@umes.edu
   employment:
     - begin_date: 2022-03-28
       end_date: 2022-08-31
       organization: columbiau
-      position: Undergradate Researcher
+      position: Undergraduate Researcher
       group: bg
       advisor: sbillinge
       status: undergrad
@@ -2143,7 +2152,7 @@ jeaster:
   grp_mtg_active: true
   name: Jaylah Y Easter
   orcid_id: ''
-  position: Undergradate Researcher
+  position: Undergraduate Researcher
 jgriffiths:
   active: true
   aka: []


### PR DESCRIPTION
In jeaster entry in people.yml: Changed data type of 'aka' from str to list, changed data type of 'bio' from str to dict, and corrected indentation of 'bio'. 